### PR TITLE
Bump bounds for ghc-9.4.5 build.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .stack-work/
+dist-newstyle/
 *~

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .stack-work/
 dist-newstyle/
+cabal.project.local
+cabal.upgrade.project.local
 *~

--- a/cabal.project
+++ b/cabal.project
@@ -1,0 +1,2 @@
+import: variadic.config
+import: https://www.stackage.org/lts-20.19/cabal.config

--- a/cabal.upgrade.project
+++ b/cabal.upgrade.project
@@ -1,0 +1,2 @@
+import: variadic.config
+import: https://www.stackage.org/nightly-2023-04-29/cabal.config

--- a/cabal.upgrade.project
+++ b/cabal.upgrade.project
@@ -1,2 +1,2 @@
 import: variadic.config
-import: https://www.stackage.org/nightly-2023-04-29/cabal.config
+import: https://www.stackage.org/nightly-2023-05-05/cabal.config

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-16.8
+resolver: lts-20.19
 
 packages:
 - variadic

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -6,7 +6,7 @@
 packages: []
 snapshots:
 - completed:
-    size: 532379
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/16/8.yaml
-    sha256: 2ad3210d2ad35f3176005d68369a18e4d984517bfaa2caade76f28ed0b2e0521
-  original: lts-16.8
+    sha256: 42f77c84b34f68c30c2cd0bf8c349f617a0f428264362426290847a6a2019b64
+    size: 649618
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/20/19.yaml
+  original: lts-20.19

--- a/variadic.config
+++ b/variadic.config
@@ -1,0 +1,1 @@
+packages: variadic

--- a/variadic/bench/Control/Variadic/Bench/NoReader.hs
+++ b/variadic/bench/Control/Variadic/Bench/NoReader.hs
@@ -19,17 +19,18 @@
 module Control.Variadic.Bench.NoReader where
 
 import Data.Coerce (Coercible, coerce)
+import Data.Kind (Type)
 import Control.Monad.Morph (MFunctor(hoist), MMonad(embed), MonadTrans(lift))
 
-type family ToVariadicArgs x :: [*] where
+type family ToVariadicArgs x :: [Type] where
   ToVariadicArgs (a -> x) = a ': ToVariadicArgs x
   ToVariadicArgs a = '[]
 
-type family ToVariadicReturn x :: * where
+type family ToVariadicReturn x :: Type where
   ToVariadicReturn (a -> x) = ToVariadicReturn x
   ToVariadicReturn a = a
 
-type family Signature (args :: [*]) r where
+type family Signature (args :: [Type]) r where
   Signature '[] r = r
   Signature (x ': xs) r = x -> Signature xs r
 
@@ -57,11 +58,11 @@ toVariadicT
   => x -> VariadicT args f a
 toVariadicT = coerce
 
-newtype Variadic (args :: [*]) (a :: *) = Variadic
+newtype Variadic (args :: [Type]) (a :: Type) = Variadic
   { runVariadic :: Signature args a
   }
 
-newtype VariadicT (args :: [*]) (f :: * -> *) (a :: *) = VariadicT
+newtype VariadicT (args :: [Type]) (f :: Type -> Type) (a :: Type) = VariadicT
   { runVariadicT :: Signature args (f a)
   }
 
@@ -74,7 +75,8 @@ fromVariadic :: Variadic args a -> Signature args a
 fromVariadic = runVariadic
 
 instance (Functor f) => Functor (VariadicT '[] f) where
-  fmap f (VariadicT x) = VariadicT $ fmap f x {-# INLINE fmap #-}
+  fmap f (VariadicT x) = VariadicT $ fmap f x
+  {-# INLINE fmap #-}
 
 instance (Functor (VariadicT args f)) => Functor (VariadicT (arg ': args) f) where
   fmap f (VariadicT x) =

--- a/variadic/bench/Control/Variadic/Bench/NoReader/Generic/Internal.hs
+++ b/variadic/bench/Control/Variadic/Bench/NoReader/Generic/Internal.hs
@@ -13,7 +13,7 @@ module Control.Variadic.Bench.NoReader.Generic.Internal where
 
 import Control.Monad.Morph (MFunctor)
 import Control.Variadic.Bench.NoReader
-import Data.Kind (Constraint)
+import Data.Kind (Constraint, Type)
 import Data.Proxy (Proxy(Proxy))
 import GHC.Generics
 import GHC.TypeLits
@@ -59,7 +59,7 @@ ghoist'
   -> r g
 ghoist' proxy f = to . gghoist proxy f . from
 
-class GHoist (i :: * -> *) (o :: * -> *) (f :: * -> *) (g :: * -> *) (ignored :: [Symbol]) where
+class GHoist (i :: Type -> Type) (o :: Type -> Type) (f :: Type -> Type) (g :: Type -> Type) (ignored :: [Symbol]) where
   gghoist :: proxy ignored -> (forall x. f x -> g x) -> i p -> o p
 
 instance (GHoist i o f g ignored) => GHoist (M1 D c i) (M1 D c o) f g ignored where

--- a/variadic/package.yaml
+++ b/variadic/package.yaml
@@ -20,7 +20,7 @@ ghc-options:
 
 dependencies:
 - base >= 4.7 && < 5
-- mmorph >= 1.1.3 && < 1.2
+- mmorph >= 1.1.3 && < 1.3
 - mtl >= 2.2.2 && < 2.3
 
 library:

--- a/variadic/src/Control/Variadic.hs
+++ b/variadic/src/Control/Variadic.hs
@@ -15,11 +15,12 @@ import Control.Monad.Morph (MFunctor(hoist), MMonad, MonadTrans)
 import Control.Monad.Reader (ReaderT(ReaderT))
 import Control.Variadic.Varargs (Varargs(Cons, Nil))
 import Data.Functor (void)
+import Data.Kind (Type)
 
 -- | Same as 'Variadic' but captures the higher-kinded type parameter in the
 -- return type. Useful so we can use 'Monad' and friends with 'Variadic'
 -- functions.
-newtype VariadicT args (m :: * -> *) a = VariadicT
+newtype VariadicT args (m :: Type -> Type) a = VariadicT
   { unVariadicT :: Variadic args (m a)
   } deriving (Functor, Applicative, Monad) via ReaderT (Varargs args) m
     deriving (MFunctor, MMonad, MonadTrans) via ReaderT (Varargs args)
@@ -47,12 +48,12 @@ newtype Variadic args a = Variadic
   }
 
 -- | Resolves the argument list for a function of arbitrary arity.
-type family ToVariadicArgs x :: [*] where
+type family ToVariadicArgs x :: [Type] where
   ToVariadicArgs (i -> o) = i ': ToVariadicArgs o
   ToVariadicArgs a = '[]
 
 -- | Resolves the return type for a function of arbitrary arity.
-type family ToVariadicReturn x :: * where
+type family ToVariadicReturn x :: Type where
   ToVariadicReturn (i -> o) = ToVariadicReturn o
   ToVariadicReturn a = a
 
@@ -78,7 +79,7 @@ instance {-# OVERLAPS #-}
       runVariadic (toVariadic (f arg)) args
 
 -- | Builds a function signature given the @args@ and return type @r@.
-type family FromVariadicSignature (args :: [*]) (r :: *) :: * where
+type family FromVariadicSignature (args :: [Type]) (r :: Type) :: Type where
   FromVariadicSignature '[] r = r
   FromVariadicSignature (arg ': args) r = arg -> FromVariadicSignature args r
 

--- a/variadic/src/Control/Variadic/Generic/Internal.hs
+++ b/variadic/src/Control/Variadic/Generic/Internal.hs
@@ -12,7 +12,7 @@
 module Control.Variadic.Generic.Internal where
 
 import Control.Variadic
-import Data.Kind (Constraint)
+import Data.Kind (Constraint, Type)
 import Data.Proxy (Proxy(Proxy))
 import GHC.Generics
 import GHC.TypeLits
@@ -58,7 +58,7 @@ ghoist'
   -> r g
 ghoist' proxy f = to . gghoist proxy f . from
 
-class GHoist (i :: * -> *) (o :: * -> *) (f :: * -> *) (g :: * -> *) (ignored :: [Symbol]) where
+class GHoist (i :: Type -> Type) (o :: Type -> Type) (f :: Type -> Type) (g :: Type -> Type) (ignored :: [Symbol]) where
   gghoist :: proxy ignored -> (forall x. f x -> g x) -> i p -> o p
 
 instance (GHoist i o f g ignored) => GHoist (M1 D c i) (M1 D c o) f g ignored where

--- a/variadic/src/Control/Variadic/Varargs.hs
+++ b/variadic/src/Control/Variadic/Varargs.hs
@@ -4,8 +4,10 @@
 {-# LANGUAGE TypeOperators #-}
 module Control.Variadic.Varargs where
 
+import Data.Kind (Type)
+
 -- | Glorified HList representing variadic arguments.
-data family Varargs (l :: [*])
+data family Varargs (l :: [Type])
 data instance Varargs '[] = Nil
 data instance Varargs (x ': xs) = x `Cons` Varargs xs
 infixr 2 `Cons`

--- a/variadic/test/Test/Infra/Handle.hs
+++ b/variadic/test/Test/Infra/Handle.hs
@@ -3,11 +3,12 @@
 {-# LANGUAGE KindSignatures #-}
 module Test.Infra.Handle where
 
+import Data.Kind (Type)
 import GHC.Generics (Generic)
 
 -- | An example handle for interacting with a database.
 -- We'll be using it as a test case for @ghoist@.
-data Handle (f :: * -> *) = Handle
+data Handle (f :: Type -> Type) = Handle
   { insert :: String -> String -> f Int
   , get :: Int -> f (Maybe (String, String))
   , delete :: Int -> f Bool

--- a/variadic/variadic.cabal
+++ b/variadic/variadic.cabal
@@ -1,10 +1,10 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.31.2.
+-- This file has been generated from package.yaml by hpack version 0.35.1.
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: d8b0b953a94896493afb01fb7d8f965e391cbb6caf5757a5293a10e8469a85e4
+-- hash: 57dccd61c2fb07f251fd03cfac67b1393e650d46833f51d01505d411e6788581
 
 name:           variadic
 version:        0.0.0.0
@@ -41,7 +41,7 @@ library
   ghc-options: -Wall
   build-depends:
       base >=4.7 && <5
-    , mmorph >=1.1.3 && <1.2
+    , mmorph >=1.1.3 && <1.3
     , mtl >=2.2.2 && <2.3
   default-language: Haskell2010
 
@@ -60,7 +60,7 @@ test-suite variadic-test
     , containers
     , hspec
     , hspec-expectations-lifted
-    , mmorph >=1.1.3 && <1.2
+    , mmorph >=1.1.3 && <1.3
     , mtl >=2.2.2 && <2.3
     , process
     , variadic
@@ -80,7 +80,7 @@ benchmark variadic-benchmark
   build-depends:
       base >=4.7 && <5
     , criterion
-    , mmorph >=1.1.3 && <1.2
+    , mmorph >=1.1.3 && <1.3
     , mtl >=2.2.2 && <2.3
     , variadic
   default-language: Haskell2010


### PR DESCRIPTION
Also satisfied `-Wstar-is-type` warning.